### PR TITLE
change pathname for Admin View

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,8 +33,8 @@ function App() {
       <Router>
         <PageLayoutWithRouter >
           <Switch>
-            <Redirect exact path="/" to="/dashboard" />
-            <Route path="/dashboard" component={AdminDashboard} />
+            <Redirect exact path="/" to="/admin-dashboard" />
+            <Route path="/admin-dashboard" component={AdminDashboard} />
             <Route path="/create-cohort" component={CreateCohort} />
             <Route path="/applicant-dashboard" component={ApplicantDashboard}/>
             <Route path="/apply/:id" component={ApplicantForm} />

--- a/src/applicant/applicant-dashboard/applicant-dashboard.js
+++ b/src/applicant/applicant-dashboard/applicant-dashboard.js
@@ -59,9 +59,6 @@ const ApplicantDashboard = props => {
     <Wrapper flex flex_column>
       <HeadWrapper flex justify_between>
         <H1 di>{t("admin.dashboard.cohort-application-form")}</H1>
-        <LinkButton color="green" size="large" link="/create-cohort">
-          {t("admin.dashboard.create-application-group")}
-        </LinkButton>
       </HeadWrapper>
       <CohortCardWrapper>
         <Router>

--- a/src/applicant/applicant-dashboard/applicant-dashboard.js
+++ b/src/applicant/applicant-dashboard/applicant-dashboard.js
@@ -5,7 +5,6 @@ import getCohorts from "../../store/actions/getCohorts";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import tachyons from "styled-components-tachyons";
-import LinkButton from "../../common/button/link";
 import CohortCard from "../../common/cohort-card/cohort-card";
 import ApplicantForm from "../applicant-form/applicant-form";
 

--- a/src/common/header/header.js
+++ b/src/common/header/header.js
@@ -5,7 +5,7 @@ import tachyons from 'styled-components-tachyons'
 
 const AdminView = ({ pathname, H4 }) => {
 
-  if (pathname && (pathname.includes('dashboard') || pathname.includes('create-cohort'))) {
+  if (pathname && (pathname.includes('admin-dashboard') || pathname.includes('create-cohort'))) {
     return (
       <H4 di self_center tr>Admin View</H4>
     );

--- a/src/translations/translations.json
+++ b/src/translations/translations.json
@@ -3,7 +3,7 @@
     "translation": {
       "admin": {
         "dashboard": {
-          "cohort-application-form": "Cohort Application Form",
+          "cohort-application-form": "Cohort Application Forms",
           "create-application-group": "Create Application Group"
         },
         "create-cohort": {


### PR DESCRIPTION
https://trello.com/c/Rbmkg6wc/115-0-c-as-an-admin-i-want-an-indicator-on-the-admin-area-of-the-app-so-that-i-know-where-i-am

- a purple header bar for the admin view that includes:
- - the title "Admin View" to the right if the user is in the admin area
- - blank on the right if the user is not in the admin area
- See attached wireframe for details around design

![Capture1](https://user-images.githubusercontent.com/41407354/65087893-6c28c600-d985-11e9-9be6-2491dda4fc73.JPG)
![Capture2](https://user-images.githubusercontent.com/41407354/65087898-71861080-d985-11e9-946d-dab5468600ec.JPG)
