### PR TITLE
dynamic titles in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10548,6 +10548,17 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
+    "react-helmet": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
+      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.4",
+        "react-fast-compare": "^2.0.2",
+        "react-side-effect": "^1.1.0"
+      }
+    },
     "react-i18next": {
       "version": "10.12.2",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-10.12.2.tgz",
@@ -10708,6 +10719,14 @@
         "webpack-dev-server": "3.2.1",
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "4.2.0"
+      }
+    },
+    "react-side-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
+      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
+      "requires": {
+        "shallowequal": "^1.0.1"
       }
     },
     "read-pkg": {
@@ -11458,6 +11477,11 @@
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^16.8.6",
     "react-datepicker": "^2.9.6",
     "react-dom": "^16.8.6",
+    "react-helmet": "^5.2.1",
     "react-i18next": "^10.12.2",
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Cohort Application</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/admin/admin-dashboard/admin-dashboard.js
+++ b/src/admin/admin-dashboard/admin-dashboard.js
@@ -1,7 +1,8 @@
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
-import getCohorts from "../../store/actions/getCohorts";
+import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
+import getCohorts from "../../store/actions/getCohorts";
 import styled from "styled-components";
 import tachyons from "styled-components-tachyons";
 import LinkButton from "../../common/button/link";
@@ -54,6 +55,10 @@ const AdminDashboard = props => {
 
   return (
     <Wrapper flex flex_column>
+      <Helmet>
+        <title>Cohort Application Forms</title>
+        <meta name="description" content="Cohort Application Forms for admin-dashboard" />
+      </Helmet>
       <HeadWrapper flex justify_between>
         <H1 di>{t("admin.dashboard.cohort-application-form")}</H1>
         <LinkButton color="green" size="large" link="/create-cohort">

--- a/src/admin/create-cohort/create-cohort.js
+++ b/src/admin/create-cohort/create-cohort.js
@@ -1,13 +1,28 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Helmet } from "react-helmet";
+import styled from "styled-components";
+import tachyons from "styled-components-tachyons";
 import CreateForm from "./create-form";
 
 const CreateCohort = () => {
   const { t } = useTranslation();
+  
+  const H1 = styled.h1`
+    padding: 0;
+    margin: 0;
+    font-size: 2rem;
+    font-weight: bold;
+    ${tachyons}
+  `;
 
   return (
     <>
-      <h1>{t("admin.create-cohort.create-new-cohort-application-form")}</h1>
+      <Helmet>
+        <title>Create New Cohort Application Form</title>
+        <meta name="description" content="Create New Cohort Application Form for admin" />
+      </Helmet>
+      <H1>{t("admin.create-cohort.create-new-cohort-application-form")}</H1>
       <CreateForm />
     </>
   );

--- a/src/applicant/applicant-dashboard/applicant-dashboard.js
+++ b/src/applicant/applicant-dashboard/applicant-dashboard.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
-import getCohorts from "../../store/actions/getCohorts";
+import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
+import getCohorts from "../../store/actions/getCohorts";
 import styled from "styled-components";
 import tachyons from "styled-components-tachyons";
 import CohortCard from "../../common/cohort-card/cohort-card";
@@ -56,6 +57,10 @@ const ApplicantDashboard = props => {
 
   return (
     <Wrapper flex flex_column>
+      <Helmet>
+        <title>Cohort Application Forms</title>
+        <meta name="description" content="Cohort Application Forms for applicant-dashboard" />
+      </Helmet>
       <HeadWrapper flex justify_between>
         <H1 di>{t("admin.dashboard.cohort-application-form")}</H1>
       </HeadWrapper>


### PR DESCRIPTION
Ticket 7A
https://trello.com/c/SrAXmkXk/119-7-a-as-a-user-i-want-the-screen-title-in-the-browser-tab-title-so-that-i-know-what-screen-im-on

- Ensure that the browser title for the app (currently "React App") is updated properly with the screen title. For example:
- - The following screen: http://bridge-applications-8-frontend.bridgeschoolapp.io/admin-dashboard should have this in the browser title: "Cohort Application Forms"
- - The following screen: http://bridge-applications-8-frontend.bridgeschoolapp.io/create-cohort "Create New Cohort Application Form"

Check: (In browser tabs) 
- admin-dashboard ---> Cohort Application Forms
- create-cohort ---> Create New Cohort Application Form
- applicant-dashboard ---> Cohort Application Forms
- default/other pages   ---> Cohort Application 
-- create-cohort ---> Create New Cohort Application Form  (I changed the text font size to be larger than before)

** I used React-Helmet, please "npm install" after merging this pull request. 

![Capture1](https://user-images.githubusercontent.com/41407354/65114435-c68d4b00-d9b4-11e9-9a25-6150896c5405.JPG)

![Capture2](https://user-images.githubusercontent.com/41407354/65114440-cbea9580-d9b4-11e9-9577-73b49dbe47cc.JPG)

![Capture3](https://user-images.githubusercontent.com/41407354/65114443-ce4cef80-d9b4-11e9-9ea7-b3e66f75e1c8.JPG)

![Capture4](https://user-images.githubusercontent.com/41407354/65114449-d311a380-d9b4-11e9-94e5-f11df331a407.JPG)
